### PR TITLE
fix links

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,14 +28,14 @@
     "configurations": {
         "repository": "https://github.com/darkwheel/pptb-userSecurityManager",
         "website": "https://github.com/darkwheel/pptb-userSecurityManager",
-        "iconUrl": "https://raw.githubusercontent.com/darkwheel/pptb-userSecurityManager/refs/heads/main/icon.png",
+        "iconUrl": "https://raw.githubusercontent.com/darkwheel/pptb-userSecurityManager/refs/heads/main/icon/icon.svg",
         "readmeUrl": "https://raw.githubusercontent.com/darkwheel/pptb-userSecurityManager/refs/heads/main/README.md"
     },
     "scripts": {
         "build": "tsc && npm run copy-html && npm run copy-css && npm run copy-icon",
         "copy-html": "shx cp src/index.html dist/",
         "copy-css": "shx cp src/styles.css dist/",
-        "copy-icon": "shx cp src/icon/icon.svg dist/",
+        "copy-icon": "shx cp icon/icon.svg dist/",
         "finalize-package": "npm shrinkwrap",
         "watch": "tsc --watch"
     },


### PR DESCRIPTION
This pull request makes a minor update to the project configuration by switching the icon file from a PNG to an SVG format and correcting the path used in the build script.

* Changed the `iconUrl` in `package.json` to point to the new SVG icon location.
* Updated the `copy-icon` build script in `package.json` to use the correct path for the SVG icon.