### PR TITLE
Implement better filter to also list roles of parent bu's

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
     "name": "@darkwheel/pptb-user-security-manager",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@darkwheel/pptb-user-security-manager",
-            "version": "0.0.5",
+            "version": "0.0.6",
             "license": "MIT",
             "devDependencies": {
                 "@pptb/types": "^1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@darkwheel/pptb-user-security-manager",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "displayName": "User Security Manager",
     "description": "A comprehensive tool to management security roles and team assignments in Power Platform environments.",
     "repository": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -455,24 +455,105 @@ async function fetchUserRoles(userId: string): Promise<any[]> {
 async function fetchAllAvailableRoles(businessUnitId: string): Promise<any[]> {
     console.log('Fetching roles for business unit:', businessUnitId);
 
+    // First, get the parent business unit chain
+    const parentBuIds = await getParentBusinessUnitChain(businessUnitId);
+    console.log('Business unit hierarchy:', [businessUnitId, ...parentBuIds]);
+
     const fetchXml = `
 <fetch>
     <entity name="role">
         <attribute name="name" />
         <attribute name="roleid" />
         <attribute name="businessunitid" />
+        <link-entity name="businessunit" from="businessunitid" to="businessunitid" alias="bu">
+            <attribute name="name" />
+        </link-entity>
     </entity>
 </fetch>`;
 
     const result = await dataverse.fetchXmlQuery(fetchXml);
     console.log('Total roles from system:', result.value.length);
 
-    // Filter roles by business unit on client side
-    const filteredRoles = result.value.filter((role: any) => role['_businessunitid_value'] === businessUnitId);
-    console.log('Roles filtered for BU:', filteredRoles.length);
-    console.log('Filtered roles:', filteredRoles);
+    // Filter roles to include user's BU and all parent BUs
+    const allowedBuIds = new Set([businessUnitId, ...parentBuIds]);
+    const filteredRoles = result.value.filter((role: any) =>
+        allowedBuIds.has(role['_businessunitid_value'])
+    );
+    console.log('Roles from user BU and parent BUs:', filteredRoles.length);
 
-    return filteredRoles;
+    // Deduplicate by role name, prioritizing user's BU over parent BUs
+    const rolesByName = new Map<string, any>();
+
+    // Sort by BU priority: user's BU first, then parents in order
+    const sortedRoles = filteredRoles.sort((a, b) => {
+        const aBuId = a['_businessunitid_value'] as string;
+        const bBuId = b['_businessunitid_value'] as string;
+
+        if (aBuId === businessUnitId) return -1;
+        if (bBuId === businessUnitId) return 1;
+
+        const aIndex = parentBuIds.indexOf(aBuId);
+        const bIndex = parentBuIds.indexOf(bBuId);
+        return aIndex - bIndex;
+    });
+
+    // Keep only first occurrence of each role name (which will be from the closest BU)
+    // Also mark if role is from a parent BU
+    sortedRoles.forEach(role => {
+        const roleName = role['name'] as string;
+        if (!rolesByName.has(roleName)) {
+            // Add flag indicating if this role is from a parent BU
+            role.isFromParentBU = role['_businessunitid_value'] !== businessUnitId;
+            rolesByName.set(roleName, role);
+        }
+    });
+
+    const deduplicatedRoles = Array.from(rolesByName.values());
+    console.log('Deduplicated roles:', deduplicatedRoles.length);
+
+    return deduplicatedRoles;
+}
+
+/**
+ * Get the parent business unit chain for a given business unit
+ */
+async function getParentBusinessUnitChain(businessUnitId: string): Promise<string[]> {
+    const parentIds: string[] = [];
+    let currentBuId: string | null = businessUnitId;
+
+    // Walk up the parent chain (max 10 levels to prevent infinite loops)
+    for (let i = 0; i < 10 && currentBuId; i++) {
+        const fetchXml = `
+<fetch top="1">
+    <entity name="businessunit">
+        <attribute name="parentbusinessunitid" />
+        <filter>
+            <condition attribute="businessunitid" operator="eq" value="${currentBuId}" />
+        </filter>
+    </entity>
+</fetch>`;
+
+        try {
+            const result = await dataverse.fetchXmlQuery(fetchXml);
+            if (result.value.length > 0) {
+                const parentBuId = result.value[0]['_parentbusinessunitid_value'] as string | undefined;
+                if (parentBuId && parentBuId !== currentBuId) {
+                    parentIds.push(parentBuId);
+                    currentBuId = parentBuId;
+                } else {
+                    // Reached root BU (no parent)
+                    break;
+                }
+            } else {
+                break;
+            }
+        } catch (error) {
+            console.error('Error fetching parent BU:', error);
+            break;
+        }
+    }
+
+    return parentIds;
 }
 
 /**
@@ -704,12 +785,19 @@ function displayUserDetails(userData: any, userRoles: any[], userTeams: any[], c
         const nameA = (a['name'] || 'N/A').toLowerCase();
         const nameB = (b['name'] || 'N/A').toLowerCase();
         return nameA.localeCompare(nameB);
-    }).map(role => `
+    }).map(role => {
+        const buName = role['bu.name'];
+        const isFromParentBU = role.isFromParentBU;
+        return `
                                     <tr data-roleid="${role['roleid']}">
                                         <td class="checkbox-cell"><input type="checkbox" class="available-role-checkbox"></td>
-                                        <td>${escapeHtml(role['name'] || 'N/A')}</td>
+                                        <td>
+                                            ${escapeHtml(role['name'] || 'N/A')}
+                                            ${isFromParentBU && buName ? `<span class="business-unit-tag parent-bu" style="margin-left: 8px;" title="From parent business unit">${escapeHtml(buName)}</span>` : ''}
+                                        </td>
                                     </tr>
-                                `).join('')}
+                                `;
+    }).join('')}
                             </tbody>
                         </table>
                     ` : '<div class="empty-message">All available roles assigned</div>'}

--- a/src/styles.css
+++ b/src/styles.css
@@ -609,6 +609,14 @@ header h1 {
     color: var(--primary-color);
 }
 
+/* Parent BU tag for roles from parent business units */
+.business-unit-tag.parent-bu {
+    background-color: #fff4e5;
+    color: #8a5500;
+    border: 1px solid #ffd699;
+    font-size: 0.8em;
+}
+
 .loading-indicator {
     text-align: center;
     padding: 40px;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,17 +2,27 @@
     "compilerOptions": {
         "target": "ES2022",
         "module": "ES2022",
-        "lib": ["ES2022", "DOM"],
+        "lib": [
+            "ES2022",
+            "DOM"
+        ],
         "outDir": "./dist",
         "rootDir": "./src",
         "strict": true,
         "esModuleInterop": true,
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "resolveJsonModule": true,
-        "types": ["@pptb/types"]
+        "types": [
+            "@pptb/types"
+        ]
     },
-    "include": ["src/**/*"],
-    "exclude": ["node_modules", "dist"]
+    "include": [
+        "src/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
 }


### PR DESCRIPTION
This pull request introduces enhancements to how security roles are fetched and displayed, particularly focusing on business unit (BU) hierarchy awareness. Now, when listing available roles, the system includes roles from both the user's BU and all parent BUs, deduplicates them by role name (prioritizing the closest BU), and visually distinguishes roles originating from parent BUs in the UI. The version is also incremented to reflect these improvements.

**Business Unit Hierarchy Role Fetching and Deduplication:**
- Enhanced the `fetchAllAvailableRoles` function in `src/app.ts` to:
  - Fetch roles from the user's BU and all parent BUs by traversing the BU hierarchy.
  - Deduplicate roles by name, favoring roles from the user's own BU over parent BUs.
  - Mark roles that originate from parent BUs for UI distinction.
  - Added a helper function `getParentBusinessUnitChain` to recursively retrieve parent BU IDs.

**User Interface Improvements:**
- Updated the role display in `displayUserDetails` in `src/app.ts` to:
  - Show a tag next to roles that are from parent BUs, including the parent BU's name.
- Added new CSS styling in `src/styles.css` for the parent BU tag, making it visually distinct.

**Versioning:**
- Bumped the package version from `0.0.5` to `0.0.6` in `package.json` and `npm-shrinkwrap.json` to reflect these changes. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-44a7c69871c5958e657226d5552c9451606a778233fb824f68530d0cfd3f8994L3-R9)