### PR TITLE
Implement pagiantion for user roles and teams

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
     "name": "@darkwheel/pptb-user-security-manager",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@darkwheel/pptb-user-security-manager",
-            "version": "0.0.6",
+            "version": "0.0.7",
             "license": "MIT",
             "devDependencies": {
                 "@pptb/types": "^1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@darkwheel/pptb-user-security-manager",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "displayName": "User Security Manager",
     "description": "A comprehensive tool to management security roles and team assignments in Power Platform environments.",
     "repository": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -394,11 +394,11 @@ async function selectUser(userId: string, userData: any) {
     try {
         // Fetch user roles, teams, team-derived roles, and all available roles in parallel
         console.log('User data:', userData);
-        console.log('User business unit ID:', userData.businessunitid);
+        console.log('User business unit ID:', userData._businessunitid_value);
         console.log('User business unit object:', userData['businessunit.businessunitid']);
 
-        // Extract business unit ID - it might be in different properties depending on how it was fetched
-        const buId = userData.businessunitid || userData['businessunit.businessunitid'];
+        // Extract business unit ID - for lookup fields, use _attributename_value
+        const buId = userData._businessunitid_value || userData['businessunit.businessunitid'];
         console.log('Extracted BU ID:', buId);
 
         const [userRoles, userTeams, teamRoles, allAvailableRoles, allAvailableTeams] = await Promise.all([
@@ -450,68 +450,71 @@ async function fetchUserRoles(userId: string): Promise<any[]> {
 }
 
 /**
+ * Generic function to fetch all records using FetchXML pagination
+ */
+async function fetchAllWithPagination(baseFetchXml: string, entityName: string): Promise<any[]> {
+    console.log(`Fetching all ${entityName} records with pagination...`);
+
+    const allRecords: any[] = [];
+    let pageNumber = 1;
+    let pagingCookie: string | null = null;
+
+    while (true) {
+        // Build FetchXML with paging
+        const parser = new DOMParser();
+        const serializer = new XMLSerializer();
+        const fetchDoc = parser.parseFromString(baseFetchXml, 'text/xml');
+        const fetchNode = fetchDoc.getElementsByTagName('fetch')[0];
+
+        fetchNode.setAttribute('page', pageNumber.toString());
+
+        if (pagingCookie) {
+            // Parse the paging cookie XML structure
+            const cookieDoc = parser.parseFromString(pagingCookie, 'text/xml');
+            const cookieAttr = cookieDoc.getElementsByTagName('cookie')[0]?.getAttribute('pagingcookie');
+
+            if (cookieAttr) {
+                // Double decode the paging cookie
+                const decodedCookie = decodeURIComponent(decodeURIComponent(cookieAttr));
+                const innerCookieDoc = parser.parseFromString(decodedCookie, 'text/xml');
+
+                // Set the paging cookie attribute
+                fetchNode.setAttribute('paging-cookie', serializer.serializeToString(innerCookieDoc));
+            }
+        }
+
+        const fetchXml = serializer.serializeToString(fetchDoc);
+
+        console.log(`Fetching ${entityName} page ${pageNumber}...`);
+        const result = await dataverse.fetchXmlQuery(fetchXml);
+
+        if (result.value && result.value.length > 0) {
+            allRecords.push(...result.value);
+            console.log(`Page ${pageNumber}: ${result.value.length} ${entityName} (total: ${allRecords.length})`);
+        }
+
+        // Check for paging cookie in result
+        const resultAny = result as any;
+        pagingCookie = resultAny.fetchXmlPagingCookie || resultAny['@Microsoft.Dynamics.CRM.fetchxmlpagingcookie'];
+
+        if (pagingCookie) {
+            pageNumber++;
+        } else {
+            // No more records
+            break;
+        }
+    }
+
+    console.log(`Total ${entityName} fetched:`, allRecords.length);
+    return allRecords;
+}
+
+/**
  * Fetch all available roles in the system for a specific business unit
  */
 async function fetchAllAvailableRoles(businessUnitId: string): Promise<any[]> {
-    console.log('Fetching roles for business unit:', businessUnitId);
-
-    // First, get the parent business unit chain
-    const parentBuIds = await getParentBusinessUnitChain(businessUnitId);
-    console.log('Business unit hierarchy:', [businessUnitId, ...parentBuIds]);
-
-    const fetchXml = `
-<fetch>
-    <entity name="role">
-        <attribute name="name" />
-        <attribute name="roleid" />
-        <attribute name="businessunitid" />
-        <link-entity name="businessunit" from="businessunitid" to="businessunitid" alias="bu">
-            <attribute name="name" />
-        </link-entity>
-    </entity>
-</fetch>`;
-
-    const result = await dataverse.fetchXmlQuery(fetchXml);
-    console.log('Total roles from system:', result.value.length);
-
-    // Filter roles to include user's BU and all parent BUs
-    const allowedBuIds = new Set([businessUnitId, ...parentBuIds]);
-    const filteredRoles = result.value.filter((role: any) =>
-        allowedBuIds.has(role['_businessunitid_value'])
-    );
-    console.log('Roles from user BU and parent BUs:', filteredRoles.length);
-
-    // Deduplicate by role name, prioritizing user's BU over parent BUs
-    const rolesByName = new Map<string, any>();
-
-    // Sort by BU priority: user's BU first, then parents in order
-    const sortedRoles = filteredRoles.sort((a, b) => {
-        const aBuId = a['_businessunitid_value'] as string;
-        const bBuId = b['_businessunitid_value'] as string;
-
-        if (aBuId === businessUnitId) return -1;
-        if (bBuId === businessUnitId) return 1;
-
-        const aIndex = parentBuIds.indexOf(aBuId);
-        const bIndex = parentBuIds.indexOf(bBuId);
-        return aIndex - bIndex;
-    });
-
-    // Keep only first occurrence of each role name (which will be from the closest BU)
-    // Also mark if role is from a parent BU
-    sortedRoles.forEach(role => {
-        const roleName = role['name'] as string;
-        if (!rolesByName.has(roleName)) {
-            // Add flag indicating if this role is from a parent BU
-            role.isFromParentBU = role['_businessunitid_value'] !== businessUnitId;
-            rolesByName.set(roleName, role);
-        }
-    });
-
-    const deduplicatedRoles = Array.from(rolesByName.values());
-    console.log('Deduplicated roles:', deduplicatedRoles.length);
-
-    return deduplicatedRoles;
+    const baseFetchXml = `<fetch count="5000"><entity name="role"><attribute name="name"/><attribute name="roleid"/><attribute name="businessunitid"/><order attribute="roleid"/><filter><condition attribute="businessunitid" operator="eq" value="${businessUnitId}"/></filter></entity></fetch>`;
+    return fetchAllWithPagination(baseFetchXml, 'roles');
 }
 
 /**
@@ -583,26 +586,8 @@ async function fetchUserTeams(userId: string): Promise<any[]> {
  * Fetch all available teams for a specific business unit
  */
 async function fetchAllAvailableTeams(businessUnitId: string): Promise<any[]> {
-    console.log('Fetching teams for business unit:', businessUnitId);
-
-    const fetchXml = `
-<fetch>
-    <entity name="team">
-        <attribute name="name" />
-        <attribute name="teamid" />
-        <attribute name="businessunitid" />
-    </entity>
-</fetch>`;
-
-    const result = await dataverse.fetchXmlQuery(fetchXml);
-    console.log('Total teams from system:', result.value.length);
-
-    // Filter teams by business unit on client side
-    const filteredTeams = result.value.filter((team: any) => team['_businessunitid_value'] === businessUnitId);
-    console.log('Teams filtered for BU:', filteredTeams.length);
-    console.log('Filtered teams:', filteredTeams);
-
-    return filteredTeams;
+    const baseFetchXml = `<fetch count="5000"><entity name="team"><attribute name="name"/><attribute name="teamid"/><attribute name="businessunitid"/><order attribute="teamid"/></entity></fetch>`;
+    return fetchAllWithPagination(baseFetchXml, 'teams');
 }
 
 /**
@@ -785,19 +770,12 @@ function displayUserDetails(userData: any, userRoles: any[], userTeams: any[], c
         const nameA = (a['name'] || 'N/A').toLowerCase();
         const nameB = (b['name'] || 'N/A').toLowerCase();
         return nameA.localeCompare(nameB);
-    }).map(role => {
-        const buName = role['bu.name'];
-        const isFromParentBU = role.isFromParentBU;
-        return `
+    }).map(role => `
                                     <tr data-roleid="${role['roleid']}">
                                         <td class="checkbox-cell"><input type="checkbox" class="available-role-checkbox"></td>
-                                        <td>
-                                            ${escapeHtml(role['name'] || 'N/A')}
-                                            ${isFromParentBU && buName ? `<span class="business-unit-tag parent-bu" style="margin-left: 8px;" title="From parent business unit">${escapeHtml(buName)}</span>` : ''}
-                                        </td>
+                                        <td>${escapeHtml(role['name'] || 'N/A')}</td>
                                     </tr>
-                                `;
-    }).join('')}
+                                `).join('')}
                             </tbody>
                         </table>
                     ` : '<div class="empty-message">All available roles assigned</div>'}

--- a/src/styles.css
+++ b/src/styles.css
@@ -609,14 +609,6 @@ header h1 {
     color: var(--primary-color);
 }
 
-/* Parent BU tag for roles from parent business units */
-.business-unit-tag.parent-bu {
-    background-color: #fff4e5;
-    color: #8a5500;
-    border: 1px solid #ffd699;
-    font-size: 0.8em;
-}
-
 .loading-indicator {
     text-align: center;
     padding: 40px;


### PR DESCRIPTION
This pull request updates the version of the `@darkwheel/pptb-user-security-manager` package and refactors how available roles and teams are fetched and displayed. The main improvements include introducing a generic FetchXML pagination utility, simplifying and optimizing data fetching for roles and teams, and cleaning up the UI by removing parent business unit tags from the roles table.

Key changes:

**Version Update**
* Bumped the package version to `0.0.7` in both `package.json` and `npm-shrinkwrap.json` to reflect the new changes. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-44a7c69871c5958e657226d5552c9451606a778233fb824f68530d0cfd3f8994L3-R9)

**Data Fetching Refactor**
* Introduced a generic `fetchAllWithPagination` function to handle FetchXML pagination for any entity, improving scalability and reducing code duplication.
* Refactored `fetchAllAvailableRoles` and `fetchAllAvailableTeams` to use the new pagination utility, ensuring all records are fetched efficiently and simplifying the logic for both roles and teams retrieval. [[1]](diffhunk://#diff-841254fe75488c1bd4cd7f68f00b4be0e48dcfbc4a16b45847b68295e0e3b27bL453-R517) [[2]](diffhunk://#diff-841254fe75488c1bd4cd7f68f00b4be0e48dcfbc4a16b45847b68295e0e3b27bL586-R590)
* Updated extraction of the business unit ID from user data to consistently use the lookup field convention (`_businessunitid_value`).

**UI & Display Simplification**
* Removed logic and UI elements related to displaying parent business unit tags for roles, streamlining the roles table display. [[1]](diffhunk://#diff-841254fe75488c1bd4cd7f68f00b4be0e48dcfbc4a16b45847b68295e0e3b27bL788-R778) [[2]](diffhunk://#diff-4753b2e6427841425517139f09f1342c320338443447af46169dc0f43a0f2cf3L612-L619)